### PR TITLE
Prevent collision on reusing botname to appservice name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 A puppeting bridge between Matrix and Telegram packaged as a YunoHost service. Messages, notifications (and sometimes media) are bridged between a Telegram user and a Matrix user. Currently the Matrix user can NOT invite other Matrix user in a bridged Telegram room, so only someone with a Telegram account can participate to Telegram group conversations. The ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/index.html) bridge is a Synapse App Service and relies on postgresql. Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Shipped version:** 0.12.2~ynh1
+**Shipped version:** 0.12.2~ynh2
 ## Disclaimers / important information
 
 ## List of known public services

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ La passerelle ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/i
 ** Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix-synapse et mautrix_telegram en même temps!**
 
 
-**Version incluse :** 0.12.2~ynh1
+**Version incluse :** 0.12.2~ynh2
 ## Avertissements / informations importantes
 
 ## Liste de passerelles publiques

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -74,7 +74,7 @@ appservice:
         shared_secret: generate
 
     # The unique ID of this appservice.
-    id: __BOTNAME__
+    id: __APPSERVICEID__
     # Username of the appservice bot.
     bot_username: __BOTNAME__
     # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Telegram puppeting bridge for Matrix/Synapse",
         "fr": "Passerelle Telegram pour Matrix/Synapse"
     },
-    "version": "0.12.2~ynh1",
+    "version": "0.12.2~ynh2",
     "url": "https://docs.mau.fi/bridges/python/telegram/index.html",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/scripts/install
+++ b/scripts/install
@@ -23,6 +23,7 @@ ynh_abort_if_errors
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
 
+appserviceid=$YNH_APP_INSTANCE_NAME
 synapsenumber=$YNH_APP_ARG_SYNAPSENUMBER
 botname=$YNH_APP_ARG_BOTNAME
 encryption=$YNH_APP_ARG_ENCRYPTION
@@ -58,6 +59,7 @@ test ! -e "$final_path" || ynh_die --message="This path already contains a folde
 #=================================================
 ynh_script_progression --message="Storing installation settings..." --weight=7
 
+ynh_app_setting_set --app=$app --key=appserviceid --value=$appserviceid
 ynh_app_setting_set --app=$app --key=botname --value=$botname
 ynh_app_setting_set --app=$app --key=encryption --value=$encryption
 ynh_app_setting_set --app=$app --key=botadmin --value=$botadmin

--- a/scripts/remove
+++ b/scripts/remove
@@ -16,6 +16,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=5
 
 app=$YNH_APP_INSTANCE_NAME
 
+appserviceid=$(ynh_app_setting_get --app=$app --key=appserviceid)
 botname=$(ynh_app_setting_get --app=$app --key=botname)
 synapse_instance=$(ynh_app_setting_get --app=$app --key=synapse_instance)
 server_name=$(ynh_app_setting_get --app=$app --key=server_name)

--- a/scripts/restore
+++ b/scripts/restore
@@ -32,6 +32,7 @@ db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_user=$db_name
 synapse_instance=$(ynh_app_setting_get --app=$app --key=synapse_instance)
 synapse_registration_path=$(ynh_app_setting_get --app=$app --key=synapse_registration_path)
+appserviceid=$(ynh_app_setting_get --app=$app --key=appserviceid)
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,6 +16,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 
 app=$YNH_APP_INSTANCE_NAME
 
+appserviceid=$(ynh_app_setting_get --app=$app --key=appserviceid)
 botname=$(ynh_app_setting_get --app=$app --key=botname)
 encryption=$(ynh_app_setting_get --app=$app --key=encryption)
 botadmin=$(ynh_app_setting_get --app=$app --key=botadmin)
@@ -67,6 +68,13 @@ ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
+
+# If appserviceid doesn't exist, create it
+if [ -z "$appserviceid" ]
+then
+  appserviceid=$app
+  ynh_app_setting_set --app=$app --key=appserviceid --value=$appserviceid
+fi
 
 #=================================================
 # CREATE DEDICATED USER


### PR DESCRIPTION
## Problem

- Many times after upgrading seems that the var ```__BOTNAME__``` used for both values id and username in the config file causes the bridge not to start and fail silently.
- In the config file itself we see as commented examples that the values of those options are meant to be different.
- See also other issues reported to mautrix_whatsapp repo:
https://github.com/mautrix/whatsapp/issues/251
https://github.com/mautrix/whatsapp/issues/238

## Solution

- Create new var ```__APPSERVICEID__``` that uses $YNH_APP_INSTANCE_NAME as value to avoid collision with other instances.
This parameter is a bit technical to be exposed to the regular user so that's why I suggest that value.
I'll also provide the config panel option to change it with the proper action to trigger update_synapse_for_appservice.sh that is needed when the value is changed.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
