### PR TITLE
Testing to master [v0.14.2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 A puppeting bridge between Matrix and Telegram packaged as a YunoHost service. Messages, notifications (and sometimes media) are bridged between a Telegram user and a Matrix user. Currently the Matrix user can NOT invite other Matrix user in a bridged Telegram room, so only someone with a Telegram account can participate to Telegram group conversations. The ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/index.html) bridge is a Synapse App Service and relies on postgresql. Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Shipped version:** 0.13.0~ynh1
+**Shipped version:** 0.14.0~ynh1
 ## Disclaimers / important information
 
 ## List of known public services

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 A puppeting bridge between Matrix and Telegram packaged as a YunoHost service. Messages, notifications (and sometimes media) are bridged between a Telegram user and a Matrix user. Currently the Matrix user can NOT invite other Matrix user in a bridged Telegram room, so only someone with a Telegram account can participate to Telegram group conversations. The ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/index.html) bridge is a Synapse App Service and relies on postgresql. Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Shipped version:** 0.14.0~ynh1
+**Shipped version:** 0.14.1~ynh1
 ## Disclaimers / important information
 
 ## List of known public services

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 A puppeting bridge between Matrix and Telegram packaged as a YunoHost service. Messages, notifications (and sometimes media) are bridged between a Telegram user and a Matrix user. Currently the Matrix user can NOT invite other Matrix user in a bridged Telegram room, so only someone with a Telegram account can participate to Telegram group conversations. The ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/index.html) bridge is a Synapse App Service and relies on postgresql. Therefore, [Synapse for YunoHost](https://github.com/YunoHost-Apps/synapse_ynh) should be installed beforehand.
 
 
-**Shipped version:** 0.14.1~ynh1
+**Shipped version:** 0.14.2~ynh1
 ## Disclaimers / important information
 
 ## List of known public services

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,7 @@ La passerelle ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/i
 ** Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix-synapse et mautrix_telegram en même temps!**
 
 
-**Version incluse :** 0.14.1~ynh1
+**Version incluse :** 0.14.2~ynh1
 ## Avertissements / informations importantes
 
 ## Liste de passerelles publiques

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,7 @@ La passerelle ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/i
 ** Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix-synapse et mautrix_telegram en même temps!**
 
 
-**Version incluse :** 0.13.0~ynh1
+**Version incluse :** 0.14.0~ynh1
 ## Avertissements / informations importantes
 
 ## Liste de passerelles publiques

--- a/README_fr.md
+++ b/README_fr.md
@@ -22,7 +22,7 @@ La passerelle ["Mautrix-Telegram"](https://docs.mau.fi/bridges/python/telegram/i
 ** Attention : sauvegardez et restaurez toujours les deux applications Yunohost matrix-synapse et mautrix_telegram en même temps!**
 
 
-**Version incluse :** 0.14.0~ynh1
+**Version incluse :** 0.14.1~ynh1
 ## Avertissements / informations importantes
 
 ## Liste de passerelles publiques

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/mautrix/telegram/archive/refs/tags/v0.13.0.tar.gz
-SOURCE_SUM=e0848c5042f6cdf3609c31e940503a1e9b3e6510ff327393dfca3b894c4b9caa
+SOURCE_URL=https://github.com/mautrix/telegram/archive/refs/tags/v0.14.0.tar.gz
+SOURCE_SUM=95a2a73f942bc4a932ef2b7029333e272a23b0e9ec0d5bccb5531e8004370f10
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/mautrix/telegram/archive/refs/tags/v0.14.0.tar.gz
-SOURCE_SUM=95a2a73f942bc4a932ef2b7029333e272a23b0e9ec0d5bccb5531e8004370f10
+SOURCE_URL=https://github.com/mautrix/telegram/archive/refs/tags/v0.14.1.tar.gz
+SOURCE_SUM=316cf75208f8776e30a8f9dc7d0825e0fb3aa34d0ad1ccfdff5acfeb665b81fa
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/mautrix/telegram/archive/refs/tags/v0.14.1.tar.gz
-SOURCE_SUM=316cf75208f8776e30a8f9dc7d0825e0fb3aa34d0ad1ccfdff5acfeb665b81fa
+SOURCE_URL=https://github.com/mautrix/telegram/archive/refs/tags/v0.14.2.tar.gz
+SOURCE_SUM=8071beb09970d7a337e1a1f7700ecd3f4ef774ba51f2e7199f0216883f023786
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -259,6 +259,23 @@ bridge:
     # Enable key sharing? If enabled, key requests for rooms where users are in will be fulfilled.
     # You must use a client that supports requesting keys from other users to use this feature.
     allow_key_sharing: false
+    # Options for deleting megolm sessions from the bridge.
+    delete_keys:
+      # Beeper-specific: delete outbound sessions when hungryserv confirms
+      # that the user has uploaded the key to key backup.
+      delete_outbound_on_ack: false
+      # Don't store outbound sessions in the inbound table.
+      dont_store_outbound: false
+      # Ratchet megolm sessions forward after decrypting messages.
+      ratchet_on_decrypt: false
+      # Delete fully used keys (index >= max_messages) after decrypting messages.
+      delete_fully_used_on_decrypt: false
+      # Delete previous megolm sessions from same device when receiving a new one.
+      delete_prev_on_new_session: false
+      # Delete megolm sessions received from a device when the device is deleted.
+      delete_on_device_delete: false
+      # Periodically delete megolm sessions when 2x max_age has passed since receiving the session.
+      periodically_delete_expired: false
     # What level of device verification should be required from users?
     #
     # Valid levels:
@@ -293,9 +310,14 @@ bridge:
       # session before changing it. The Matrix spec recommends 100 as the
       # default.
       messages: 100
-  # Whether or not to explicitly set the avatar and room name for private
-  # chat portal rooms. This will be implicitly enabled if encryption.default is true.
-  private_chat_portal_meta: false
+  # Whether to explicitly set the avatar and room name for private chat portal rooms.
+  # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
+  # If set to `always`, all DM rooms will have explicit names and avatars set.
+  # If set to `never`, DM rooms will never have names and avatars set.
+  private_chat_portal_meta: default
+  # Disable generating reply fallbacks? Some extremely bad clients still rely on them,
+  # but they're being phased out and will be completely removed in the future.
+  disable_reply_fallbacks: false
   # Whether or not the bridge should send a read receipt from the bridge bot when a message has
   # been sent to Telegram.
   delivery_receipts: false
@@ -344,6 +366,9 @@ bridge:
     # Even without MSC2716, bridging old messages with correct timestamps requires the double
     # puppets to be in an appservice namespace, or the server to be modified to allow
     # overriding timestamps anyway.
+    #
+    # Also note that adding users to the appservice namespace may have unexpected side effects,
+    # as described in https://docs.mau.fi/bridges/general/double-puppeting.html#appservice-method
     double_puppet_backfill: false
     # Whether or not to enable backfilling in normal groups.
     # Normal groups have numerous technical problems in Telegram, and backfilling normal groups
@@ -356,11 +381,19 @@ bridge:
     #
     # Using a negative initial limit is not recommended, as it would try to backfill everything in a single batch.
     # MSC2716 and the incremental settings are meant for backfilling everything incrementally rather than at once.
-    forward:
+    forward_limits:
       # Number of messages to backfill immediately after creating a portal.
-      initial_limit: 10
+      initial:
+        user: 50
+        normal_group: 100
+        supergroup: 10
+        channel: 10
       # Number of messages to backfill when syncing chats.
-      sync_limit: 100
+      sync:
+        user: 100
+        normal_group: 100
+        supergroup: 100
+        channel: 100
     # Settings for incremental backfill of history. These only apply when using MSC2716.
     incremental:
       # Maximum number of messages to backfill per batch.
@@ -434,7 +467,6 @@ bridge:
   # Filter rooms that can/can't be bridged. Can also be managed using the `filter` and
   # `filter-mode` management commands.
   #
-  # Filters do not affect direct chats.
   # An empty blacklist will essentially disable the filter.
   filter:
     # Filter mode to use. Either "blacklist" or "whitelist".
@@ -443,6 +475,11 @@ bridge:
     mode: blacklist
     # The list of group/channel IDs to filter.
     list: []
+    # How to handle direct chats:
+    # If users is "null", direct chats will follow the previous settings.
+    # If users is "true", direct chats will always be bridged.
+    # If users is "false", direct chats will never be bridged.
+    users: true
   # The prefix for commands. Only required in non-management rooms.
   command_prefix: "!tg"
   # Messages sent upon joining a management room.

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -37,7 +37,7 @@ appservice:
   max_body_size: 1
   # The full URI to the database. SQLite and Postgres are supported.
   # Format examples:
-  #   SQLite:   sqlite:///filename.db
+  #   SQLite:   sqlite:filename.db
   #   Postgres: postgres://username:password@hostname/dbname
   database: postgres://__DB_USER__:__DB_PWD__@localhost:5432/__DB_NAME__
   # Additional arguments for asyncpg.create_pool() or sqlite3.connect()
@@ -276,6 +276,10 @@ bridge:
       delete_on_device_delete: false
       # Periodically delete megolm sessions when 2x max_age has passed since receiving the session.
       periodically_delete_expired: false
+      # Delete inbound megolm sessions that don't have the received_at field used for
+      # automatic ratcheting and expired session deletion. This is meant as a migration
+      # to delete old keys prior to the bridge update.
+      delete_outdated_inbound: false
     # What level of device verification should be required from users?
     #
     # Valid levels:
@@ -310,6 +314,9 @@ bridge:
       # session before changing it. The Matrix spec recommends 100 as the
       # default.
       messages: 100
+      # Disable rotating keys when a user's devices change?
+      # You should not enable this option unless you understand all the implications.
+      disable_device_change_key_rotation: false
   # Whether to explicitly set the avatar and room name for private chat portal rooms.
   # If set to `default`, this will be enabled in encrypted rooms and disabled in unencrypted rooms.
   # If set to `always`, all DM rooms will have explicit names and avatars set.
@@ -569,6 +576,8 @@ telegram:
     # is not recommended, since some requests can always trigger a call fail (such as searching
     # for messages).
     request_retries: 5
+    # Use IPv6 for Telethon connection
+    use_ipv6: false
   # Device info sent to Telegram.
   device_info:
     # "auto" = OS name+version.

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -401,6 +401,8 @@ bridge:
         normal_group: 100
         supergroup: 100
         channel: 100
+    # Timeout for forward backfills in seconds. If you have a high limit, you'll have to increase this too.
+    forward_timeout: 900
     # Settings for incremental backfill of history. These only apply when using MSC2716.
     incremental:
       # Maximum number of messages to backfill per batch.

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Telegram puppeting bridge for Matrix/Synapse",
         "fr": "Passerelle Telegram pour Matrix/Synapse"
     },
-    "version": "0.14.1~ynh1",
+    "version": "0.14.2~ynh1",
     "url": "https://docs.mau.fi/bridges/python/telegram/index.html",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Telegram puppeting bridge for Matrix/Synapse",
         "fr": "Passerelle Telegram pour Matrix/Synapse"
     },
-    "version": "0.14.0~ynh1",
+    "version": "0.14.1~ynh1",
     "url": "https://docs.mau.fi/bridges/python/telegram/index.html",
     "upstream": {
         "license": "AGPL-3.0-or-later",

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Telegram puppeting bridge for Matrix/Synapse",
         "fr": "Passerelle Telegram pour Matrix/Synapse"
     },
-    "version": "0.13.0~ynh1",
+    "version": "0.14.0~ynh1",
     "url": "https://docs.mau.fi/bridges/python/telegram/index.html",
     "upstream": {
         "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Notes

- Security: Updated Pillow to 10.0.1.
- Added support for double puppeting with arbitrary as_tokens. See [docs](https://docs.mau.fi/bridges/general/double-puppeting.html#appservice-method-new) for more info.
- Added support for sending webm and tgs files as stickers.
- Updated to Telegram API layer 161.
- Fixed cached usernames for Telegram users being cleared incorrectly, leading to mentions not being bridged as usernames.
- Fixed reaction bridging failing if the server running the bridge was rebooted less than 12 hours ago.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
