### PR TITLE
Fix permissions

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -30,7 +30,7 @@ appservice:
   tls_cert: false
   tls_key: false
   # The hostname and port where this appservice should listen.
-  hostname: 0.0.0.0
+  hostname: 127.0.0.1
   port: __PORT__
   # The maximum body size of appservice API requests (from the homeserver) in mebibytes
   # Usually 1 is enough, but on high-traffic bridges you might need to increase this to avoid 413s

--- a/manifest.toml
+++ b/manifest.toml
@@ -114,10 +114,8 @@ default = "disabled"
 	autoupdate.strategy = "latest_github_release"
 
 	[resources.system_user]
-	home = "/opt/yunohost/__APP__"
 
 	[resources.install_dir]
-	dir = "/opt/yunohost/__APP__"
 
 	[resources.permissions]
 	main.allowed = "all_users"

--- a/scripts/install
+++ b/scripts/install
@@ -71,6 +71,10 @@ ynh_script_progression "Setting up source files..."
 
 ynh_setup_source --dest_dir="$install_dir/src"
 
+chmod 750 "$install_dir"
+chmod -R 750 "$install_dir"
+chown -R $app:$app "$install_dir"
+
 #=================================================
 # ADD A CONFIGURATION
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -26,6 +26,10 @@ ynh_script_progression "Restoring the app main directory..."
 
 ynh_restore "$install_dir"
 
+chmod 750 "$install_dir"
+chmod -R 750 "$install_dir"
+chown -R $app:$app "$install_dir"
+
 #=================================================
 # RESTORE THE POSTGRESQL DATABASE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -165,6 +165,10 @@ ynh_script_progression "Upgrading source files..."
 
 ynh_setup_source --dest_dir="$install_dir/src"
 
+chmod 750 "$install_dir"
+chmod -R 750 "$install_dir"
+chown -R $app:$app "$install_dir"
+
 #=================================================
 # UPDATE A CONFIG FILE
 #=================================================


### PR DESCRIPTION
## Problem

`config.yaml` was owned by `root` and not by `mautrix_telegram` which caused the service not to start. Fixes #85 .

## Solution

Chowning the full `$install_dir` according to how it's done in `mautrix_whatsapp` (without the second redundant `chown`), see https://github.com/search?q=repo%3AYunoHost-Apps%2Fmautrix_whatsapp_ynh%20chown&type=code .

Also moving the installation from `/opt/yunohost/mautrix_telegram` to the default directory `/var/www/mautrix_telegram`.

Edit: Also updated `hostname` in `config.yaml` from `0.0.0.0` to `127.0.0.1` to fix security issue (according to how it's done in `mautrix_whatsapp`, see https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/blob/master/conf/config.yaml#L300C15-L300C24).

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
